### PR TITLE
Don't assume that there is a resource id

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,8 +7,7 @@
     options.
 -->
 
-<phpunit addUncoveredFilesFromWhitelist="true"
-         backupGlobals="false"
+<phpunit backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
@@ -16,9 +15,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         processUncoveredFilesFromWhitelist="true"
          stopOnFailure="false"
-         syntaxCheck="false"
          verbose="true">
 
     <testsuites>
@@ -32,7 +29,7 @@
     </php>
 
     <filter>
-        <whitelist>
+        <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src/</directory>
             <exclude>
                 <!--<file>src/file.php</file>-->
@@ -48,15 +45,10 @@
     <logging>
         <log type="coverage-html"
              target="./build/coverage"
-             title="Garbage Man Suite"
-             charset="UTF-8"
-             yui="true"
-             highlight="true"
              lowUpperBound="35"
              highLowerBound="70"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
         <log type="json" target="./build/logs/logfile.json"/>
-        <log type="junit" target="./build/logs/junit.xml"
-             logIncompleteSkipped="true"/>
+        <log type="junit" target="./build/logs/junit.xml"/>
     </logging>
 </phpunit>

--- a/src/Support/ModelResolver.php
+++ b/src/Support/ModelResolver.php
@@ -1147,8 +1147,8 @@ class ModelResolver
         // Bust the resource into the parts
         $uri_parts = parse_url($uri);
 
-        // Trim /\\d+ off the end
-        $pattern = preg_replace('|/\\d+$|u', '', $uri_parts['path']);
+        // Trim /\\d* off the end (i.e. '/' or '/123')
+        $pattern = preg_replace('|/\\d*$|u', '', $uri_parts['path']);
 
         // Replace /\\d+/ with /{id}}/
         $pattern = preg_replace('|/\\d+/|u', '/{id}/', $pattern);

--- a/src/Support/ModelResolver.php
+++ b/src/Support/ModelResolver.php
@@ -1147,14 +1147,14 @@ class ModelResolver
         // Bust the resource into the parts
         $uri_parts = parse_url($uri);
 
-        // Trim /\\d* off the end (i.e. '/' or '/123')
-        $pattern = preg_replace('|/\\d*$|u', '', $uri_parts['path']);
+        // Trim "/" off the end
+        $pattern = rtrim($uri_parts['path'], '/');
 
-        // Replace /\\d+/ with /{id}}/
-        $pattern = preg_replace('|/\\d+/|u', '/{id}/', $pattern);
+        // Replace /(/)d+(/?)/ with /$1{id}$2/
+        $pattern = preg_replace('|(/)\\d+(/?)|u', '$1{id}$2', $pattern);
 
         // Make regex
-        $pattern = '|^/?' . $pattern . '/?\\d*?$|ui';
+        $pattern = '|^/' . $pattern . '$|ui';
 
         // This is convoluted, but it is getting the first value of the filtered resources that the key matches the
         // associative array

--- a/tests/Support/ModelResolverTest.php
+++ b/tests/Support/ModelResolverTest.php
@@ -32,6 +32,11 @@ class ModelResolverTest extends TestCase
         $this->assertEquals('Some/Model', $resolver->find('some/uri/'), 'simple uris with trailing slash');
         $this->assertEquals('Some/Model', $resolver->find('/some/uri/'), 'simple uris with leading & trailing slash');
         $this->assertEquals('Some/ModelWithParam', $resolver->find('some/uri/45'), 'uri to direct resource');
+        $this->assertEquals(
+            'Some/ModelWithParam',
+            $resolver->find('some/uri/45?param=1&param=2'),
+            'uri to direct resource'
+        );
         $this->assertEquals('Some/Model', $resolver->find('some/uri?param=1&param=2'), 'uri with parameters');
 
         $this->assertEquals('Other/Model', $resolver->find('specific/987/uri'), 'nested resource uri');

--- a/tests/Support/ModelResolverTest.php
+++ b/tests/Support/ModelResolverTest.php
@@ -22,19 +22,39 @@ class ModelResolverTest extends TestCase
     public function it_finds_the_expected_model()
     {
         $resolver = new ModelResolver([
-            'some/uri'          => 'Some/Model',
-            'specific/{id}/uri' => 'Other/Model',
+            '/some/uri'          => 'Some/Model',
+            '/some/uri/{id}'     => 'Some/ModelWithParam',
+            '/specific/{id}/uri' => 'Other/Model',
         ]);
 
-        $this->assertEquals('Some/Model', $resolver->find('some/uri'));
-        $this->assertEquals('Some/Model', $resolver->find('/some/uri'));
-        $this->assertEquals('Some/Model', $resolver->find('some/uri/45'));
-        $this->assertEquals('Some/Model', $resolver->find('some/uri?param=1&param=2'));
+        $this->assertEquals('Some/Model', $resolver->find('some/uri'), 'simple uri');
+        $this->assertEquals('Some/Model', $resolver->find('/some/uri'), 'simple uri with leading slash');
+        $this->assertEquals('Some/Model', $resolver->find('some/uri/'), 'simple uris with trailing slash');
+        $this->assertEquals('Some/Model', $resolver->find('/some/uri/'), 'simple uris with leading & trailing slash');
+        $this->assertEquals('Some/ModelWithParam', $resolver->find('some/uri/45'), 'uri to direct resource');
+        $this->assertEquals('Some/Model', $resolver->find('some/uri?param=1&param=2'), 'uri with parameters');
 
-        $this->assertEquals('Other/Model', $resolver->find('specific/987/uri'));
-        $this->assertEquals('Other/Model', $resolver->find('/specific/987/uri'));
-        $this->assertEquals('Other/Model', $resolver->find('specific/987/uri/45'));
-        $this->assertEquals('Other/Model', $resolver->find('specific/987/uri?param=1&param=2'));
+        $this->assertEquals('Other/Model', $resolver->find('specific/987/uri'), 'nested resource uri');
+        $this->assertEquals(
+            'Other/Model',
+            $resolver->find('/specific/987/uri'),
+            'nested resource uri with leading slash'
+        );
+        $this->assertEquals(
+            'Other/Model',
+            $resolver->find('specific/987/uri/'),
+            'nested resource uri with trialing slash'
+        );
+        $this->assertEquals(
+            'Other/Model',
+            $resolver->find('/specific/987/uri/'),
+            'nested resource uri with leading & trialing slash'
+        );
+        $this->assertEquals(
+            'Other/Model',
+            $resolver->find('specific/987/uri?param=1&param=2'),
+            'nested resource uri with parameters'
+        );
     }
 
     /**


### PR DESCRIPTION
@ssfinney We found this bug where responses were not always getting cast because the regex pattern was off.

This addresses the issue.