### PR TITLE
Improve passing options to the client by setting the "body" key and e…

### DIFF
--- a/src/Api/Client.php
+++ b/src/Api/Client.php
@@ -224,12 +224,10 @@ class Client
      */
     public function buildOptions(array $options = [])
     {
-        return array_merge_recursive(
-            $options,
-            [
-                'headers' => $this->getHeaders(),
-            ]
-        );
+        return [
+            'body'    => json_encode($options ?? []),
+            'headers' => $this->getHeaders(),
+        ];
     }
 
     /**

--- a/tests/Api/ClientTest.php
+++ b/tests/Api/ClientTest.php
@@ -294,7 +294,7 @@ class ClientTest extends TestCase
         $this->client->setIntegrator($username);
 
         $options = [
-            'extra'   => 'option',
+            'body'    => json_encode(['extra' => 'option']),
             'headers' => [
                 'added'         => 'header',
                 'Accept'        => 'application/vnd.connectwise.com+json; version=2019.5',


### PR DESCRIPTION
…ncoding the options in JSON so the user doesn't have to.

For example, I have to do this to pass in data to the client:

```php
        $patch_data = [
            'body' => json_encode(
                [
                    'op'    => 'replace',
                    'path'  => '/priority/id',
                    'value' => $priority['id'],
                ]
            ),
        ];
```

With this PR I'll only have to do this:

```php
        $patch_data = [
                    'op'    => 'replace',
                    'path'  => '/priority/id',
                    'value' => $priority['id'],
                ];
```